### PR TITLE
rename istio mesh as per meshdiscovery refactor

### DIFF
--- a/supergloo/docs/tutorials/istio/tutorials-1-trafficshifting.md
+++ b/supergloo/docs/tutorials/istio/tutorials-1-trafficshifting.md
@@ -111,7 +111,7 @@ The equivalent non-interactive command:
 supergloo apply routingrule trafficshifting \
     --name reviews-v3 \
     --dest-upstreams supergloo-system.default-reviews-9080 \
-    --target-mesh supergloo-system.istio \
+    --target-mesh supergloo-system.istio-istio-system \
     --destination supergloo-system.default-reviews-v3-9080:1
 ```
 
@@ -140,7 +140,7 @@ spec:
               namespace: supergloo-system
           weight: 1
   targetMesh:
-    name: istio
+    name: istio-istio-system
     namespace: supergloo-system
 status:
   reported_by: istio-config-reporter
@@ -161,7 +161,7 @@ Lets update our rule to split traffic between the `v2` and `v3` versions of revi
 supergloo apply routingrule trafficshifting \
     --name reviews-v3 \
     --dest-upstreams supergloo-system.default-reviews-9080 \
-    --target-mesh supergloo-system.istio \
+    --target-mesh supergloo-system.istio-istio-system \
     --destination supergloo-system.default-reviews-v2-9080:1 \
     --destination supergloo-system.default-reviews-v3-9080:1
 ```

--- a/supergloo/docs/tutorials/istio/tutorials-2-root-cert.md
+++ b/supergloo/docs/tutorials/istio/tutorials-2-root-cert.md
@@ -191,7 +191,7 @@ type: Opaque
 Finally, we must tell SuperGloo to use this secret for certificate provisioning in our mesh:
 
 ```bash
-supergloo set rootcert --target-mesh supergloo-system.istio \
+supergloo set rootcert --target-mesh supergloo-system.istio-istio-system \
     --tls-secret supergloo-system.my-root-ca
 ```
 
@@ -199,7 +199,7 @@ supergloo set rootcert --target-mesh supergloo-system.istio \
 +----------+-------+------+
 |   MESH   | TYPE  | MTLS |
 +----------+-------+------+
-| my-istio | Istio | true |
+| istio-istio-system | Istio | true |
 +----------+-------+------+
 ```
 

--- a/supergloo/docs/tutorials/istio/tutorials-2-root-cert.md
+++ b/supergloo/docs/tutorials/istio/tutorials-2-root-cert.md
@@ -191,16 +191,16 @@ type: Opaque
 Finally, we must tell SuperGloo to use this secret for certificate provisioning in our mesh:
 
 ```bash
-supergloo set rootcert --target-mesh supergloo-system.istio-istio-system \
+supergloo set mesh rootcert --target-mesh supergloo-system.istio-istio-system \
     --tls-secret supergloo-system.my-root-ca
 ```
 
 ```noop
-+----------+-------+------+
-|   MESH   | TYPE  | MTLS |
-+----------+-------+------+
++--------------------+-------+------+
+|        MESH        | TYPE  | MTLS |
++--------------------+-------+------+
 | istio-istio-system | Istio | true |
-+----------+-------+------+
++--------------------+-------+------+
 ```
 
 > Note: `target-mesh` should be set to the `NAMESPACE.NAME` of the managed mesh you'd like to configure. To

--- a/supergloo/docs/tutorials/istio/tutorials-3-prometheus-metrics.md
+++ b/supergloo/docs/tutorials/istio/tutorials-3-prometheus-metrics.md
@@ -57,7 +57,7 @@ when it is connected to that instance's configmap. Run the following command to 
 
 ```bash
 supergloo set mesh stats \
-    --target-mesh supergloo-system.istio \
+    --target-mesh supergloo-system.istio-istio-system \
     --prometheus-configmap prometheus-test.prometheus-server
 ```
 
@@ -90,7 +90,7 @@ kubectl --namespace prometheus-test get configmap --output yaml | grep istio
 We can see the configuration that this applied to our Mesh CRD by running:
 
 ```bash
-kubectl --namespace supergloo-system get mesh istio --output yaml
+kubectl --namespace supergloo-system get mesh istio-istio-system --output yaml
 ```
 
 {{< highlight yaml "hl_lines=14-17" >}}
@@ -99,7 +99,7 @@ kind: Mesh
 metadata:
   creationTimestamp: 2019-03-28T18:44:46Z
   generation: 1
-  name: istio
+  name: istio-istio-system
   namespace: supergloo-system
   resourceVersion: "178284"
   selfLink: /apis/supergloo.solo.io/v1/namespaces/supergloo-system/meshes/istio

--- a/supergloo/docs/tutorials/istio/tutorials-4-fault-injection.md
+++ b/supergloo/docs/tutorials/istio/tutorials-4-fault-injection.md
@@ -82,7 +82,7 @@ The equivalent non-interactive command:
 
 ```bash
 supergloo apply routingrule faultinjection abort http \
-    --target-mesh supergloo-system.istio \
+    --target-mesh supergloo-system.istio-istio-system \
     -p 50 -s 404 --name rule1 \
     --dest-upstreams supergloo-system.default-reviews-9080
 ```
@@ -107,7 +107,7 @@ spec:
         httpStatus: 404
       percentage: 50
   targetMesh:
-    name: istio
+    name: istio-istio-system
     namespace: supergloo-system
 status:
   reported_by: istio-config-reporter
@@ -129,7 +129,7 @@ Let's update our rule to cause a delay instead.
 
 ```bash
 supergloo apply routingrule faultinjection delay fixed \
-    --target-mesh supergloo-system.istio \
+    --target-mesh supergloo-system.istio-istio-system \
     -p 50 -d 5s --name rule1 \
     --dest-upstreams supergloo-system.default-reviews-9080
 ```

--- a/supergloo/docs/tutorials/istio/tutorials-5-security.md
+++ b/supergloo/docs/tutorials/istio/tutorials-5-security.md
@@ -66,7 +66,7 @@ spec:
       - name: default-productpage-9080
         namespace: supergloo-system
   targetMesh:
-    name: istio
+    name: istio-istio-system
     namespace: supergloo-system
 
 ```
@@ -149,7 +149,7 @@ supergloo apply securityrule \
     --namespace default \
     --source-upstreams supergloo-system.default-productpage-9080 \
     --dest-upstreams supergloo-system.default-productpage-9080 \
-    --target-mesh supergloo-system.istio
+    --target-mesh supergloo-system.istio-istio-system
 ```
 
 - Or, using `kubectl`:
@@ -173,7 +173,7 @@ spec:
       - name: default-productpage-9080
         namespace: supergloo-system
   targetMesh:
-    name: istio
+    name: istio-istio-system
     namespace: supergloo-system
 EOF
 ```
@@ -199,7 +199,7 @@ supergloo apply securityrule \
     --namespace default \
     --source-upstreams supergloo-system.default-productpage-9080 \
     --dest-upstreams supergloo-system.default-details-9080 \
-    --target-mesh supergloo-system.istio
+    --target-mesh supergloo-system.istio-istio-system
 ```
 
 - Or with `kubectl`:
@@ -223,7 +223,7 @@ spec:
       - name: default-productpage-9080
         namespace: supergloo-system
   targetMesh:
-    name: istio
+    name: istio-istio-system
     namespace: supergloo-system
 EOF
 ```
@@ -243,7 +243,7 @@ supergloo apply securityrule \
     --namespace default \
     --source-upstreams supergloo-system.default-productpage-9080 \
     --dest-namespaces default \
-    --target-mesh supergloo-system.istio
+    --target-mesh supergloo-system.istio-istio-system
 ```
 
 - Or with `kubectl`:
@@ -266,7 +266,7 @@ spec:
       - name: default-productpage-9080
         namespace: supergloo-system
   targetMesh:
-    name: istio
+    name: istio-istio-system
     namespace: supergloo-system
 EOF
 ```

--- a/supergloo/docs/tutorials/istio/tutorials-6-istio-mtls.md
+++ b/supergloo/docs/tutorials/istio/tutorials-6-istio-mtls.md
@@ -52,7 +52,7 @@ Assuming that the exact names of the earlier tutorials were used, the command wi
 #### Option 1: CLI
 
 ```bash
-supergloo install gloo --name gloo --target-meshes supergloo-system.istio
+supergloo install gloo --name gloo --target-meshes supergloo-system.istio-istio-system
 ```
 
 #### Option 2: yaml
@@ -69,7 +69,7 @@ spec:
     gloo:
     glooVersion: 0.13.13
     meshes:
-    - name: istio
+    - name: istio-istio-system
       namespace: supergloo-system
   installationNamespace: gloo-system
 EOF
@@ -163,7 +163,7 @@ Now that we have verified that we cannot access the route, the next step is to a
 order to tell gloo to enable ssl with the istio certs. supergloo has a command to accomplish just that.
 
 ```bash
-supergloo set upstream mtls --name  default-details-9080 --target-mesh supergloo-system.istio
+supergloo set upstream mtls --name  default-details-9080 --target-mesh supergloo-system.istio-istio-system
 ```
 
 After this command completes successfully the upstream should contain the following. Notice the certificates in

--- a/supergloo/docs/tutorials/istio/tutorials-7-istio-smi.md
+++ b/supergloo/docs/tutorials/istio/tutorials-7-istio-smi.md
@@ -53,7 +53,7 @@ smi-adapter-istio-f564fbcd8-xlchp        1/1     Running     0          2m53s
 We can verify that SuperGloo's `meshdiscovery` service has detected that SMI has been enabled for istio:
 
 ```bash
-kubectl get mesh -n supergloo-system istio -o yaml
+kubectl get mesh -n supergloo-system istio-istio-system -o yaml
 ```
 
 {{< highlight yaml "hl_lines=29" >}}
@@ -65,7 +65,7 @@ metadata:
   labels:
     created_by: mesh-discovery
     discovered_by: istio-mesh-discovery
-  name: my-istio
+  name: istio-istio-system
   namespace: supergloo-system
   resourceVersion: "6968896"
   selfLink: /apis/supergloo.solo.io/v1/namespaces/supergloo-system/meshes/my-istio

--- a/supergloo/docs/tutorials/linkerd/tutorials-1-retries.md
+++ b/supergloo/docs/tutorials/linkerd/tutorials-1-retries.md
@@ -162,7 +162,7 @@ Run the following command to create a simple RoutingRule with the retry config w
 ```bash
 supergloo apply routingrule retries budget \
     --name retries \
-    --target-mesh supergloo-system.linkerd \
+    --target-mesh supergloo-system.linkerd-linkerd \
     --min-retries 3 \
     --ratio 0.1 \
     --ttl 1m
@@ -185,7 +185,7 @@ spec:
         retryRatio: 0.1
         ttl: 60s
   targetMesh:
-    name: linkerd
+    name: linkerd-linkerd
     namespace: supergloo-system
 EOF
 ```


### PR DESCRIPTION
wherever istio and linkerd mesh names are referenced, they have been renamed in accordance with the updates to supergloo discovery