### PR TITLE
Migrate to latest theme which adds menuTitle back

### DIFF
--- a/gloo/Makefile
+++ b/gloo/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes/hugo-theme-soloio ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 9bd197dddd126e613785e682df01cab706d7831e; fi
+	if [ ! -d themes/hugo-theme-soloio ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/glooshot/Makefile
+++ b/glooshot/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 9bd197dddd126e613785e682df01cab706d7831e; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/sqoop/Makefile
+++ b/sqoop/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 9bd197dddd126e613785e682df01cab706d7831e; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/squash/Makefile
+++ b/squash/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 9bd197dddd126e613785e682df01cab706d7831e; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/supergloo/Makefile
+++ b/supergloo/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 9bd197dddd126e613785e682df01cab706d7831e; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site


### PR DESCRIPTION
This also adds initial support for tabs, like this: 

Example markdown:
```
---
title: Command Line Reference
menuTitle: CLI
weight: 6
---

The `glooctl` command line tool. Select a command from the menu for more information. 

{{< tabs name="kubectl_install" >}}
{{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
sudo apt-get update && sudo apt-get install -y apt-transport-https
curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
sudo apt-get update
sudo apt-get install -y kubectl
{{< /tab >}}
{{< tab name="CentOS, RHEL or Fedora" codelang="bash" >}}cat <<EOF > /etc/yum.repos.d/kubernetes.repo
[kubernetes]
name=Kubernetes
baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
enabled=1
gpgcheck=1
repo_gpgcheck=1
gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
EOF
yum install -y kubectl
{{< /tab >}}
{{< /tabs >}}
```

Example site: 
![image](https://user-images.githubusercontent.com/27434432/60974058-62387600-a2f7-11e9-9190-e78197778253.png)


There is a bit of work to do on tabs to get the styling / behavior right, so none of the pages are currently using them. But opening a PR to get menuTitle support back. 