### PR TITLE
Update docs with new toggles to disable gloo enterprise only components

### DIFF
--- a/gloo/docs/installation/enterprise/_index.md
+++ b/gloo/docs/installation/enterprise/_index.md
@@ -109,6 +109,32 @@ and use it to override default values in the Gloo Helm chart:
 helm install gloo/gloo --name gloo-custom-0-7-6 --namespace my-namespace -f value-overrides.yaml
 ```
 
+#### List of Gloo Helm chart values
+
+The table below describes all the enterprise-only values that you can override in your custom values file.
+
+The table for gloo open-source overrides (also available in enterprise) is [here](../gateway/kubernetes/#list-of-gloo-helm-chart-values).
+
+| option                                                    | type     | description                                                                                                                                                                                                                                                    |
+| --------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| grafana.enabled                                           | bool     | deploy grafana in your gloo system namespace. default is `true` |
+| prometheus.enabled                                        | bool     | deploy prometheus in your gloo system namespace. default is `true` |
+| rateLimit.enabled                                         | bool     | deploy rate-limiting in your gloo system namespace. default is `true` |
+
+A common setup may be to run your own prometheus (and grafana), separate from the gloo-provided ones. The enterprise Gloo UI makes use of its own grafana to display dashboards for Envoy and Kubernetes, leveraging gloo custom resources such as `Upstreams`. You can point gloo's system grafana toward your prometheus by overriding grafana's datasources tag, i.e.
+
+```yaml
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: gloo
+          type: prometheus
+          access: proxy
+          url: http://{{ your.prometheus }}:{{ your.port }}  # fill this in!
+          isDefault: true
+``` 
 
 ---
 ## Verify your Installation

--- a/gloo/docs/introduction/_index.md
+++ b/gloo/docs/introduction/_index.md
@@ -10,7 +10,7 @@ weight: 1
 
 * **Next-generation API gateway** : Gloo provides a long list of API gateway features, including rate limiting, circuit breaking, retries, caching, external authentication and authorization, transformation, service-mesh integration, and security. Getting traffic to your microservices and existing monoliths can be an expensive and complicated matter; Gloo solves these problems by keeping a slim profile, secure and separate control plane, as well as layers into infrastructure you may already have (i.e., Kubernetes, Consul, EC2, etc).
 
-* **Kubernetes ingress controller**: Gloo can function as a feature-rich ingress controller when deployed on Kubernetes and especially simplifies routing capabi    lities when deployed into public clouds like AWS EKS.
+* **Kubernetes ingress controller**: Gloo can function as a feature-rich ingress controller when deployed on Kubernetes and especially simplifies routing capabilities when deployed into public clouds like AWS EKS.
 
 * **Hybrid apps**: Gloo creates applications that route to backends implemented as microservices, serverless functions, and legacy apps. This feature can help users to gradually migrate from their legacy code to microservices and serverless; can let users add new functionalities using cloud-native technologies while maintaining their legacy codebase; can be used in cases where different teams in an organization choose different architectures; and more. See [here](https://www.solo.io/hybrid-app) for more on the Hybrid App paradigm.
 


### PR DESCRIPTION
Updates the docs to reflect the new enterprise-only toggles to disable gloo rate-limiting, prometheus, and grafana if desired. 