### PR TITLE
Bump hugo solo theme to allow notice shortcodes to render markdown

### DIFF
--- a/gloo/Makefile
+++ b/gloo/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes/hugo-theme-soloio ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout cc5c093c67463a9c2b8cc68b501264a24fb0980d; fi
+	if [ ! -d themes/hugo-theme-soloio ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 1f51653dee82a0d33a96add6a0e7fccc2ad08d6c; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/glooshot/Makefile
+++ b/glooshot/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 1f51653dee82a0d33a96add6a0e7fccc2ad08d6c; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/sqoop/Makefile
+++ b/sqoop/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 1f51653dee82a0d33a96add6a0e7fccc2ad08d6c; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/squash/Makefile
+++ b/squash/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 1f51653dee82a0d33a96add6a0e7fccc2ad08d6c; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/supergloo/Makefile
+++ b/supergloo/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout f84e248c9bec01a368c96490acbda512fafa27c8; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 1f51653dee82a0d33a96add6a0e7fccc2ad08d6c; fi
 	hugo --config docs.toml
 
 .PHONY: deploy-site

--- a/testrepo/Makefile
+++ b/testrepo/Makefile
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------------
 
 site:
-	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 9bd197dddd126e613785e682df01cab706d7831e; fi
+	if [ ! -d themes ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio && git --git-dir=themes/hugo-theme-soloio/.git checkout 1f51653dee82a0d33a96add6a0e7fccc2ad08d6c; fi
 	hugo --config docs.toml
 
 .PHONY: serve-site


### PR DESCRIPTION
Should fix https://github.com/solo-io/solo-docs/issues/515

cc @rickducott 