### PR TITLE
gloo: auth/jwt: fix link to API reference

### DIFF
--- a/gloo/docs/gloo_routing/virtual_services/authentication/jwt/_index.md
+++ b/gloo/docs/gloo_routing/virtual_services/authentication/jwt/_index.md
@@ -52,7 +52,7 @@ and cannot be used to sign new JWTs. The JWT can be independently verified by an
 ## JWTs in Gloo
 Gloo supports JWT verification using the JWT extension. You can define multiple JWT providers.
 In each provider you can specify where to find the keys required for JWT verification, the 
-values for the issuer and audience claims to verify, as well as [other settings](../../../v1/github.com/solo-io/solo-projects/projects/gloo/api/v1/plugins/jwt/jwt.proto.sk/#provider).
+values for the issuer and audience claims to verify, as well as [other settings](../../../../v1/github.com/solo-io/solo-projects/projects/gloo/api/v1/plugins/jwt/jwt.proto.sk/#provider).
 
 We have a few guides that go into more details:
 


### PR DESCRIPTION
`v1/github.com/...` is beneath `gloo/docs/`, therefore 4 (instead 3) hops upwards from `gloo/docs/gloo_routing/virtual_services/authentication/jwt/`.