### PR TITLE
Simplify rate limit docs by putting examples first explanations secon…

### DIFF
--- a/gloo/docs/gloo_routing/virtual_services/rate_limiting/envoy/_index.md
+++ b/gloo/docs/gloo_routing/virtual_services/rate_limiting/envoy/_index.md
@@ -6,18 +6,20 @@ weight: 20
 
 ## Overview
 
-In this document, we show how to use Gloo with [Envoy's rate-limit API](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/rate_limit_filter). We make the distinction here that this is "Envoy's" rate-limit API because Gloo [offers a much simpler rate-limit API](../simple) as an alternative.
+In this document, we show how to use Gloo with [Envoy's rate-limit API](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/http/rate_limit/v2/rate_limit.proto). We make the distinction here that this is "Envoy's" rate-limit API because Gloo [offers a much simpler rate-limit API](../simple) as an alternative.
 
-Gloo Enterprise includes a rate limit server based on [Lyft's Envoy rate-limit server](https://github.com/lyft/ratelimit). It is already installed when doing `glooctl install gateway --license-key=...` or using the [Helm install]({{% ref "/installation/enterprise" %}}). To get your trial license key, go to <https://www.solo.io/gloo-trial>
+Gloo Enterprise includes a rate limit server based on [Lyft's Envoy rate-limit server](https://github.com/lyft/ratelimit). It is already installed when doing `glooctl install gateway --license-key=...` or using the [Helm install]({{% ref "/installation/enterprise#installing-on-kubernetes-with-helm" %}}). To get your trial license key, go to <https://www.solo.io/gloo-trial>
 
-Two steps are needed in configuring Gloo to leverage the full Envoy Rate Limiter.
+Two steps are needed to configure Gloo to leverage the full Envoy Rate Limiter.
 
-1. In the Gloo Settings manifest, you need to configure all of your [rate limiting descriptors](https://github.com/lyft/ratelimit#configuration). These are based on the [Lyft Rate Limiting service](https://github.com/lyft/ratelimit) included with Gloo Enterprise.
-2. For each Virtual Service, you need to configure [Envoy rate limiting actions](https://www.envoyproxy.io/docs/envoy/v1.9.0/api-v2/api/v2/route/route.proto#route-ratelimit-action) at the Virtual Service level or for each route or both.
+1. In the Gloo Settings manifest, you need to configure all of your [rate limiting descriptors](https://github.com/lyft/ratelimit#configuration). Descriptors describe your requests and are used to define the rate limits themselves.
+2. For each Virtual Service, you need to configure [Envoy rate limiting actions](https://www.envoyproxy.io/docs/envoy/v1.9.0/api-v2/api/v2/route/route.proto#route-ratelimit-action) at the Virtual Service level, for each route, or both. These actions define the relationship between a request and its generated descriptors.
 
-Rate limiting descriptors define a set (tuple) of keys that must match for the associated rate limit to be applied. The set of keys are expressed as a hierarchy to make configuration easy; its the set of keys matching or not that is important. Each descriptor key can have an associated value that is matched as a literal. If there is no value associated with a key, then each unique value is used for rate limiting, that is if one of the keys is 'user_id' with no associated value then Envoy does per user rate limiting with each unique user_id value being used as the id for rate limiting. See the [Lyft rate limiting descriptors](https://github.com/lyft/ratelimit#configuration) for full details.
+#### Descriptors
 
-For example, the following descriptor will match against two keys `('account_id', '<unique value>'), ('plan', 'BASIC | PLUS')`. Since the `account_id` key does not specify a descriptor value, it uses each unique value passed into the rate limiting service to match, i.e., per account rate limiting. The `plan` descriptor key has two values specified and depending on which one matches (`BASIC` or `PLUS`) determines the rate limit, either 1 request per minute for `BASIC` or 20 requests per minute for `PLUS`. You can specify multiple descriptors, and the most specific match is what determines the rate limit.
+Rate limiting descriptors define a set (tuple) of keys that must match for the associated rate limit to be applied. The set of keys are expressed as a hierarchy to make configuration easy, but it's the set of keys matching or not that is important. Each descriptor key can have an associated value that is matched as a literal. If there is no value associated with a key, then each unique value is used for rate limiting. In essence, if one of the keys is `user_id` with no associated value then Envoy does per user rate limiting with each unique `user_id` value being used as the ID for rate limiting. See the [Lyft rate limiting descriptors](https://github.com/lyft/ratelimit#configuration) for full details.
+
+For example, look at following descriptor:
 
 ```yaml
 descriptors:
@@ -35,7 +37,9 @@ descriptors:
       unit: MINUTE
 ```
 
-The descriptors are defined in the Gloo Settings manifest.
+This descriptor will match any request with the `account_id` and `plan` keys, such that `('account_id', '<unique value>'), ('plan', 'BASIC | PLUS')`. Since the `account_id` key does not specify a descriptor value, it uses each unique value passed into the rate limiting service to match; i.e., per account rate limiting. The `plan` descriptor key has two values specified and depending on which one matches (`BASIC` or `PLUS`) determines the rate limit, either 1 request per minute for `BASIC` or 20 requests per minute for `PLUS`. You can specify multiple descriptors by nesting descriptors in other descriptors; the most specific match is what determines the rate limit.
+
+The descriptors are defined in the Gloo Settings manifest:
 
 {{< highlight yaml "hl_lines=11-12" >}}
 apiVersion: gloo.solo.io/v1
@@ -52,11 +56,13 @@ spec:
           - # list of descriptors here
 {{< /highlight >}}
 
+#### Actions
+
 The [Envoy rate limiting actions](https://www.envoyproxy.io/docs/envoy/v1.9.0/api-v2/api/v2/route/route.proto#route-ratelimit-action) associated with the Virtual Service or the individual routes allow you to specify how parts of the request are associated to rate limiting descriptor keys. For example, you can use the `requestHeaders` configuration to pass the value of a request header in as the value of the associated rate limiting descriptor key. Or you can use the `genericKey` to pass in a literal value such as a route identifier to allow you to rate limit differently based on the matched route.
 
 You can specify more than one rate limit action, and the request is throttled if any one of the actions triggers the rate limiting service to signal throttling, i.e., the rate limiting actions are effectively OR'd together.
 
-An example of the rate limiting actions is as follows. This action says to pass in the request header values as the descriptor values. That is, the `x-account-id` request header is sent to the rate limiting service as the descriptor key `account_id`.
+An example of the rate limiting actions follows:
 
 ```yaml
 rate_limits:
@@ -68,12 +74,9 @@ rate_limits:
       descriptorKey: plan
       headerName: x-plan
 ```
+This action says to pass in the request header values as the descriptor values. That is, the `x-account-id` request header is sent to the rate limiting service as the descriptor key `account_id`.
 
-Rate limit actions can be specified both at the Virtual Service level and on a per route basis. For example, the following sets up a default (virtual service level) rate limit action that maps header `x-account-id` to descriptor key `account_id` and `x-plan` to key `plan`. Any requests matching route prefix `/service/service2` use this rate limit action. Requests matching prefix `/service/service` route use a different rate limiting action that maps header `x-plan-other` to key `plan`. Note the route also has an `includeVhRateLimits: <boolean>` configuration that defaults to `false`. If `true`, any specified Virtual Service level rate limit actions would be added to (OR'd) the routes list of actions. Each rate limit action is matched to descriptors independently.
-
-{{% notice info %}}
-The Envoy rate limiter uses a plugin extension name of `envoy-rate-limit`. The Gloo simpler rate limiter uses a plugin extension of `rate-limit`.
-{{% /notice %}}
+Rate limit actions can be specified both at the Virtual Service level and on a per route basis. For example, the look at the following:
 
 {{< highlight yaml "hl_lines=22-31 42-50" >}}
 apiVersion: gateway.solo.io/v1
@@ -128,6 +131,12 @@ spec:
                   headerName: x-plan
 {{< /highlight >}}
 
+{{% notice info %}}
+The Envoy rate limiter uses a plugin extension name of `envoy-rate-limit`. The Gloo simpler rate limiter uses a plugin extension of `rate-limit`.
+{{% /notice %}}
+
+This virtual service sets up a default (virtual service level) rate limit action that maps header `x-account-id` to descriptor key `account_id` and `x-plan` to key `plan`. Any requests matching route prefix `/service/service2` use this rate limit action. Requests matching prefix `/service/service` route use a different rate limiting action that maps header `x-plan-other` to key `plan`. Note the route also has an `includeVhRateLimits: <boolean>` configuration that defaults to `false`. If `true`, any specified Virtual Service level rate limit actions would be added to (OR'd) the routes list of actions. Each rate limit action is matched to descriptors independently.
+
 ## Rate Limiting Example
 
 Install the pet clinic demo app and configure a route to that service in Gloo
@@ -166,7 +175,7 @@ Edit the rate limit server settings. This opens your default editor controlled b
 glooctl edit settings --namespace gloo-system --name default ratelimit custom-server-config
 ```
 
-That command opens the rate limit server configuration in your editor. Paste the following descriptor block into the editor. This descriptor uses `generic_key` key, which works with the `generic_key` rate limiting action in Envoy, and effectively passes a literal value to the rate limiting service. For your convenience, you can download the descriptor block [here](serverconfig.yaml). The structure of the rate limit server configuration is a list of keys and is expressed as a hierarchy for ease of configuration. For more information, see [here](https://github.com/lyft/ratelimit).
+That command opens the rate limit server configuration in your editor. Paste the following descriptor block into the editor. This descriptor uses `generic_key` key, which works with the `generic_key` rate limiting action in Envoy, effectively passing a literal value to the rate limiting service. For your convenience, you can download the descriptor block [here](serverconfig.yaml).
 
 ```yaml
 descriptors:
@@ -177,7 +186,7 @@ descriptors:
     value: some_value
 ```
 
-The `glooctl` tool merges those descriptors into the Gloo Settings manifest like as follows.
+The `glooctl` tool merges those descriptors into the Gloo Settings manifest as follows:
 
 {{< highlight yaml "hl_lines=18-23" >}}
 apiVersion: gloo.solo.io/v1
@@ -258,9 +267,9 @@ transfer-encoding: chunked
 
 ## Other Configuration Options
 
-Envoy queries an external server (backed by redis) to achieve global rate limiting.
-You can set a timeout for the query, and what to do in case the query fails.
-By default, the timeout is set to 100ms, and the failure policy is to allow the request.
+Envoy queries an external server (backed by redis) to achieve global rate limiting. You can set a timeout for the
+query, and what to do in case the query fails. By default, the timeout is set to 100ms, and the failure policy is
+to allow the request.
 
 {{% notice tip %}}
 You can check if envoy has errors with rate limiting by examining its stats that end in `ratelimit.error`.
@@ -281,4 +290,4 @@ glooctl edit settings --name default --namespace gloo-system ratelimit --deny-on
 
 ## Conclusion
 
-With the custom rate-limit configuration option, you have the full power of Envoy rate limits to use for your custom use cases. The downside to this is the API is a bit more complicated. To leverage a simpler API that can do true per-user (logged-in, authenticated user) rate limits, take a look at [Gloo's simplified ratelimit API](../simple).
+With the custom rate-limit configuration option, you have the full power of Envoy rate limits at your disposal. The downside is that the API is a bit more complicated. To leverage a simpler API that can do true per-user (logged-in, authenticated user) rate limits, take a look at [Gloo's simplified ratelimit API](../simple).


### PR DESCRIPTION
…d and adding headers. Improve grammar and make more concise as well

Simplify confusing envoy rate limiting docs by:
* Putting the examples before the explanation
* adding headers for descriptors and actions sections
* improve grammar
* remove redundancy and make docs more concise
* fix some broken links