### PR TITLE
fix hugo header

### DIFF
--- a/gloo/docs/gloo_routing/virtual_services/delegation/_index.md
+++ b/gloo/docs/gloo_routing/virtual_services/delegation/_index.md
@@ -2,8 +2,7 @@
 menuTitle: Delegation
 title: Delegating with Route Tables
 weight: 10
-description: >
- Virtual Services can delegate ownership of configuration to Route Tables, top-level API objects which specify routes for a given domain and path prefix.
+description: Virtual Services can delegate ownership of configuration to Route Tables, top-level API objects which specify routes for a given domain and path prefix.
 
 ---
 


### PR DESCRIPTION
this restores search

issue was that hugo produced an invalid index.json file that could not be parsed by search

noticed through degraded search (could only search page) and console log