### PR TITLE
quick install docs update

### DIFF
--- a/gloo/docs/installation/cluster_setup.md
+++ b/gloo/docs/installation/cluster_setup.md
@@ -37,9 +37,9 @@ You're all set. Gloo install guide [here](../).
 
 ---
 
-## Minishift / OpenShift
+## Minishift
 
-Ensure you're running a standard Minishift cluster or OpenShift cluster, e.g. `minishift start`, and verify that your `kubectl` context is
+Ensure you're running a standard Minishift cluster, e.g. `minishift start`, and verify that your `kubectl` context is
 correctly pointing to it. More details on Minishift [here](https://github.com/minishift/minishift).
 
 ```bash

--- a/gloo/docs/installation/enterprise/_index.md
+++ b/gloo/docs/installation/enterprise/_index.md
@@ -4,41 +4,14 @@ description: How to install Gloo to run in Gateway Mode on Kubernetes (Default).
 weight: 10
 ---
 
-## Install command line tool (CLI)
+## Installing the Gloo Gateway on Kubernetes
 
-The `glooctl` command line provides useful functions to install, configure, and debug Gloo, though it is not required to use Gloo.
+These directions assume you've prepared your Kubernetes cluster appropriately. Full details on setting up your
+Kubernetes cluster [here](../../cluster_setup).
 
-* To install `glooctl` using the [Homebrew](https://brew.sh) package manager, run the following.
+Note: For certain providers with more strict multi-tenant security, like OpenShift, be sure to follow the cluster set up accordingly. 
 
-  ```shell
-  brew install solo-io/tap/glooctl
-  ```
-
-* To install on any platform run the following.
-
-  ```bash
-  curl -sL https://run.solo.io/gloo/install | sh
-
-  export PATH=$HOME/.gloo/bin:$PATH
-  ```
-
-* You can download `glooctl` directly via the GitHub releases page. You need to add `glooctl` to your system's `PATH` after downloading.
-
-Verify the CLI is installed and running correctly with:
-
-```bash
-glooctl version
-```
-returns
-```shell
-Client: {"version":"0.18.43"}
-Server: {"type":"Gateway","enterprise":true,"kubernetes":{"containers":[{"Tag":"0.18.29","Name":"grpcserver-ui","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"grpcserver-ee","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"grpcserver-envoy","Registry":"quay.io/solo-io"},{"Tag":"0.18.40","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"extauth-ee","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"gloo-ee-envoy-wrapper","Registry":"quay.io/solo-io"},{"Tag":"0.18.40","Name":"gateway","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"gloo-ee","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"observability-ee","Registry":"quay.io/solo-io"},{"Tag":"0.18.29","Name":"rate-limit-ee","Registry":"quay.io/solo-io"},{"Tag":"5","Name":"redis","Registry":"docker.io"}],"namespace":"gloo-system"}}
-```
-
-If you run `glooctl --version`, you may notice that glooctl reports as a community version, but it supports enterprise commands so long as a valid license key is provided.
-
-## Installing Gloo Enterprise on Kubernetes
-
+{{< readfile file="installation/glooctl_setup.md" markdown="true" >}}
 
 {{% notice note %}}
 To install Gloo Enterprise you need a License Key. If you don't have one, go to **https://solo.io/glooe-trial** and

--- a/gloo/docs/installation/gateway/kubernetes/_index.md
+++ b/gloo/docs/installation/gateway/kubernetes/_index.md
@@ -4,43 +4,14 @@ description: How to install Gloo to run in Gateway Mode on Kubernetes (Default).
 weight: 2
 ---
 
-## Install command line tool (CLI)
-
-The `glooctl` command line provides useful functions to install, configure, and debug Gloo, though it is not required to use Gloo.
-
-* To install `glooctl` using the [Homebrew](https://brew.sh) package manager, run the following.
-
-  ```shell
-  brew install solo-io/tap/glooctl
-  ```
-
-* To install on any platform run the following.
-
-  ```bash
-  curl -sL https://run.solo.io/gloo/install | sh
-
-  export PATH=$HOME/.gloo/bin:$PATH
-  ```
-
-* You can download `glooctl` directly via the GitHub releases page. You need to add `glooctl` to your system's `PATH` after downloading.
-
-Verify the CLI is installed and running correctly with:
-
-```bash
-glooctl version
-```
-returns
-```shell
-Client: {"version":"0.18.43"}
-Server: {"type":"Gateway","kubernetes":{"containers":[{"Tag":"0.18.43","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gateway","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo","Registry":"quay.io/solo-io"}],"namespace":"gloo-system"}}
-```
-
 ## Installing the Gloo Gateway on Kubernetes
 
 These directions assume you've prepared your Kubernetes cluster appropriately. Full details on setting up your
 Kubernetes cluster [here](../../cluster_setup).
 
 Note: For certain providers with more strict multi-tenant security, like OpenShift, be sure to follow the cluster set up accordingly. 
+
+{{< readfile file="installation/glooctl_setup.md" markdown="true" >}}
 
 ### Installing on Kubernetes with `glooctl`
 

--- a/gloo/docs/installation/glooctl_setup.md
+++ b/gloo/docs/installation/glooctl_setup.md
@@ -1,0 +1,30 @@
+### Install command line tool (CLI)
+
+The `glooctl` command line provides useful functions to install, configure, and debug Gloo, though it is not required to use Gloo.
+
+* To install `glooctl` using the [Homebrew](https://brew.sh) package manager, run the following.
+
+  ```shell
+  brew install solo-io/tap/glooctl
+  ```
+
+* To install on any platform run the following.
+
+  ```bash
+  curl -sL https://run.solo.io/gloo/install | sh
+
+  export PATH=$HOME/.gloo/bin:$PATH
+  ```
+
+* You can download `glooctl` directly via the GitHub releases page. You need to add `glooctl` to your system's `PATH` after downloading.
+
+Verify the CLI is installed and running correctly with:
+
+```bash
+glooctl version
+```
+The command returns your client version and a missing server version (we have not installed Gloo yet!):
+```shell
+Client: {"version":"0.20.3"}
+Server: version undefined, could not find any version of gloo running
+```

--- a/gloo/docs/installation/ingress/_index.md
+++ b/gloo/docs/installation/ingress/_index.md
@@ -4,41 +4,12 @@ description: How to install Gloo to run in Ingress Mode on Kubernetes.
 weight: 4
 ---
 
-## Install command line tool (CLI)
-
-The `glooctl` command line provides useful functions to install, configure, and debug Gloo, though it is not required to use Gloo.
-
-* To install `glooctl` using the [Homebrew](https://brew.sh) package manager, run the following.
-
-  ```shell
-  brew install solo-io/tap/glooctl
-  ```
-
-* To install on any platform run the following.
-
-  ```bash
-  curl -sL https://run.solo.io/gloo/install | sh
-
-  export PATH=$HOME/.gloo/bin:$PATH
-  ```
-
-* You can download `glooctl` directly via the GitHub releases page. You need to add `glooctl` to your system's `PATH` after downloading.
-
-Verify the CLI is installed and running correctly with:
-
-```bash
-glooctl version
-```
-returns
-```shell
-Client: {"version":"0.18.43"}
-Server: {"type":"Knative","kubernetes":{"containers":[{"Tag":"0.18.43","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"ingress","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"}],"namespace":"gloo-system"}}
-```
-
 ## Installing the Gloo Ingress Controller on Kubernetes
 
 These directions assume you've prepared your Kubernetes cluster appropriately. Full details on setting up your
 Kubernetes cluster [here](../cluster_setup).
+
+{{< readfile file="installation/glooctl_setup.md" markdown="true" >}}
 
 ### Installing on Kubernetes with `glooctl`
 

--- a/gloo/docs/installation/knative/_index.md
+++ b/gloo/docs/installation/knative/_index.md
@@ -15,42 +15,12 @@ This guide walks you through installing Gloo and Knative using `glooctl`, the Gl
 Gloo can be installed via its [Helm Chart]({{< ref "/installation/gateway/kubernetes#installing-on-kubernetes-with-helm" >}}), which will permit fine-grained configuration of installation parameters.
 {{% /notice %}}
 
-
-## Install command line tool (CLI)
-
-The `glooctl` command line provides useful functions to install, configure, and debug Gloo, though it is not required to use Gloo.
-
-* To install `glooctl` using the [Homebrew](https://brew.sh) package manager, run the following.
-
-  ```shell
-  brew install solo-io/tap/glooctl
-  ```
-
-* To install on any platform run the following.
-
-  ```bash
-  curl -sL https://run.solo.io/gloo/install | sh
-
-  export PATH=$HOME/.gloo/bin:$PATH
-  ```
-
-* You can download `glooctl` directly via the GitHub releases page. You need to add `glooctl` to your system's `PATH` after downloading.
-
-Verify the CLI is installed and running correctly with:
-
-```bash
-glooctl version
-```
-returns
-```shell
-Client: {"version":"0.18.43"}
-Server: {"type":"Knative","kubernetes":{"containers":[{"Tag":"0.18.43","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"ingress","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"},{"Tag":"0.18.43","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"}],"namespace":"gloo-system"}}
-```
-
 ## Installing the Gloo Knative Ingress on Kubernetes
 
 These directions assume you've prepared your Kubernetes cluster appropriately. Full details on setting up your
 Kubernetes cluster [here](../cluster_setup).
+
+{{< readfile file="installation/glooctl_setup.md" markdown="true" >}}
 
 ### Installing on Kubernetes with `glooctl`
 


### PR DESCRIPTION
* reuse glooctl install content in docs
* change output of `glooctl version` to be correct for first time users (reports missing server version)
* remove confusing remarks regarding `--glooctl version` from enterprise docs