### PR TITLE
Update header matching docs

### DIFF
--- a/gloo/docs/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
+++ b/gloo/docs/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
@@ -22,7 +22,7 @@ use `:authority` (HTTP/2) as the name instead.
   * If no value is specified, then the presence of the header in the request with any value will match
 ([Envoy present_match](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-headermatcher-present-match))
   * If present, then field value interpreted based on the value of `regex` field
-* `invertMatch` - inverts the matching logic. A request matches if it does**not** match the above criteria.
+* `invertMatch` - inverts the matching logic. A request matches if it does **not** match the above criteria.
 
 ## Setup
 

--- a/gloo/docs/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
+++ b/gloo/docs/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
@@ -4,6 +4,11 @@ weight: 20
 description: Matching based on incoming or generated headers
 ---
 
+{{% notice note %}}
+The `invertMatch` attribute was introduced with **Gloo**, release 0.20.9. If you are using an earlier version, the 
+attribute will not be available.
+{{% /notice %}}
+
 When configuring the matcher on a route, you may want to specify one or more 
 [Header Matchers]({{% ref "/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk#headermatcher" %}}) to require headers 
 with matching values be present on the request. Each header matcher has three attributes:
@@ -17,6 +22,7 @@ use `:authority` (HTTP/2) as the name instead.
   * If no value is specified, then the presence of the header in the request with any value will match
 ([Envoy present_match](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-headermatcher-present-match))
   * If present, then field value interpreted based on the value of `regex` field
+* `invertMatch` - inverts the matching logic. A request matches if it does**not** match the above criteria.
 
 ## Setup
 
@@ -47,29 +53,41 @@ glooctl add route --name test-header --header "header1=value1" --header "header2
 {{< /tab >}}
 {{< /tabs >}}
 
-We can now make a curl request to the new virtual services, and set valid values for each header. In this case, header1 must equal value1, 
-header2 can equal any value, and header3 can equal any value that is a single lowercase letter. 
+We can now make a curl request to the new virtual service and set valid values for each header. In this case, 
+
+- `header1` must be present and equal value1, 
+- `header2` must be present and can equal any value, 
+- `header3` must be present and can equal any value that is a single lowercase letter, and
+- `header4` must not be present
+
+Let's send a request that satisfies all these criteria:
 
 ```shell
 curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v"  $GATEWAY_URL/posts
 ```
 
-This returns a json list of posts. 
+This returns a `json` list of posts. 
 
-If we use an incorrect value for header1, we'll see a 404:
+If we use an incorrect value for `header1`, we'll see a 404:
 
 ```shell
 curl -v -H "Host: foo" -H "header1: othervalue" -H "header2: value2" -H "header3: v"  $GATEWAY_URL/posts
 ```
 
-If we use a different value for header2, we'll see all the posts:
+If we use a different value for `header2`, we'll see all the posts:
 ```shell
 curl -v -H "Host: foo" -H "header1: value1" -H "header2: othervalue" -H "header3: v"  $GATEWAY_URL/posts
 ```
 
-And if we use an invalid value for header3, we'll get a 404: 
+If we use an invalid value for `header3`, we'll get a 404: 
 ```shell
 curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: value3"  $GATEWAY_URL/posts
+```
+
+The `invertMatch` attribute in the last entry causes request to be matched only if the do **not** include a header named 
+`header4`. If we send a request with that header, we'll get a 404 response:
+```shell
+curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v" -H "header4: value4"  $GATEWAY_URL/posts
 ```
 
 ## Summary

--- a/gloo/docs/gloo_routing/virtual_services/routes/matching_rules/header_matching/virtual-service.yaml
+++ b/gloo/docs/gloo_routing/virtual_services/routes/matching_rules/header_matching/virtual-service.yaml
@@ -16,6 +16,8 @@ spec:
             - name: header3
               regex: true
               value: "[a-z]{1}"
+            - name: header4
+              invertMatch: true
           prefix: /
         routeAction:
           single:


### PR DESCRIPTION
Document new `invertMatch` attribute in header matcher docs.

***Do not approve this until the feature is released*** (presumably with Gloo 0.20.9).